### PR TITLE
Changing PerfectHashDictionary.number() argument type to CharSequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .*
 *.class
+/target

--- a/src/main/java/eu/danieldk/dictomaton/PerfectHashDictionary.java
+++ b/src/main/java/eu/danieldk/dictomaton/PerfectHashDictionary.java
@@ -16,7 +16,7 @@ public interface PerfectHashDictionary extends Dictionary {
      * @return The perfect hash value of the sequence or <tt>-1</tt> if the sequence is
      *         not in the automaton.
      */
-    public int number(String seq);
+    public int number(CharSequence seq);
 
     /**
      * Compute the sequence corresponding to the given hash code.

--- a/src/main/java/eu/danieldk/dictomaton/PerfectHashDictionaryStateCard.java
+++ b/src/main/java/eu/danieldk/dictomaton/PerfectHashDictionaryStateCard.java
@@ -34,7 +34,7 @@ class PerfectHashDictionaryStateCard extends DictionaryImpl implements PerfectHa
      * @param seq
      * @return
      */
-    public int number(String seq) {
+    public int number(CharSequence seq) {
         int state = 0;
         int num = 0;
 

--- a/src/main/java/eu/danieldk/dictomaton/PerfectHashDictionaryTransCard.java
+++ b/src/main/java/eu/danieldk/dictomaton/PerfectHashDictionaryTransCard.java
@@ -34,7 +34,7 @@ class PerfectHashDictionaryTransCard extends DictionaryImpl implements PerfectHa
      * @param seq
      * @return
      */
-    public int number(String seq) {
+    public int number(CharSequence seq) {
         int state = 0;
         int num = 0;
 


### PR DESCRIPTION
In some cases users of PerfectHashDictionary.number() might want to avoid the creation of Strings when they call the method, for example, if their input just references a section/sections of an array of characters. 

This change would not break existing applications as CharSequence is a generalisation of String.
